### PR TITLE
Reverse domain storage, remove extensions

### DIFF
--- a/scrapy_cdr/es_upload.py
+++ b/scrapy_cdr/es_upload.py
@@ -26,7 +26,7 @@ def main():
         help='ES type to use ("document" by default)')
     arg('--op-type', default='index',
         choices={'index', 'create', 'delete', 'update'},
-        help='ES operation type to use ("document" by default)')
+        help='ES operation type to use ("index" by default)')
     arg('--broken', action='store_true',
         help='specify if input might be broken (incomplete)')
     arg('--host', default='localhost', help='ES host in host[:port] format')

--- a/scrapy_cdr/media_pipeline.py
+++ b/scrapy_cdr/media_pipeline.py
@@ -81,10 +81,7 @@ class CDRMediaPipeline(FilesPipeline):
 
     def file_path(self, request, response=None, info=None):
         assert response is not None
-        name = hashlib.sha256(response.body).hexdigest().upper()
-        parsed = urlsplit(request.url)
-        media_ext = os.path.splitext(parsed.path)[1]
-        return '{}{}'.format(name, media_ext)
+        return hashlib.sha256(response.body).hexdigest().upper()
 
     def media_downloaded(self, response, request, info):
         result = super(CDRMediaPipeline, self)\

--- a/tests/test_media_pipeline.py
+++ b/tests/test_media_pipeline.py
@@ -17,7 +17,7 @@ class Spider(scrapy.Spider):
     def __init__(self, url):
         super(Spider, self).__init__()
         self.start_urls = [url]
-        self.le = LinkExtractor()
+        self.le = LinkExtractor(canonicalize=False)
         self.files_le = LinkExtractor(
             tags=['a'], attrs=['href'], deny_extensions=[], canonicalize=False)
 
@@ -83,6 +83,7 @@ def test_media_pipeline(tmpdir):
     assert len(root_item['objects']) == 2
     file_item = find_item('/file.pdf', root_item['objects'], 'obj_original_url')
     assert file_item['obj_original_url'] == root_url + '/file.pdf'
+    assert not file_item['obj_stored_url'].endswith('.pdf')
     with tmpdir.join(file_item['obj_stored_url']).open('rb') as f:
         assert f.read() == FILE_CONTENTS
     assert file_item['content_type'] == 'application/pdf'


### PR DESCRIPTION
Add an option to put files in a reverse domain order in the file system during ES upload. Also do not store file extensions